### PR TITLE
Add colors parameter to ner_visualizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ visualize_ner(doc, labels=nlp.get_pipe("ner").labels)
 | `show_table`    | bool          | Whether to show a table of entities and their attributes. Defaults to `True`. |
 | `title`         | Optional[str] | Title of the visualizer block.                                                |
 | `sidebar_title` | Optional[str] | Title of the config settings in the sidebar.                                  |
+| `colors`        | Dict[str,str] | A dictionary mapping labels to display colors ({"LABEL": "COLOR"})            |
+
 
 #### <kbd>function</kbd> `visualize_textcat`
 
@@ -232,7 +234,7 @@ spacy_model = st.sidebar.selectbox("Model name", ["en_core_web_sm", "en_core_web
 nlp = load_model(spacy_model)
 ```
 
-| Argument    | Type       | Description                                              |
-| ----------- | ---------- | -------------------------------------------------------- |
-| `name`      | str        |  Loadable spaCy model name. Can be path or package name. |
-| **RETURNS** | `Language` | The loaded `nlp` object.                                 |
+| Argument    | Type       | Description                                             |
+| ----------- | ---------- | ------------------------------------------------------- |
+| `name`      | str        | Loadable spaCy model name. Can be path or package name. |
+| **RETURNS** | `Language` | The loaded `nlp` object.                                |

--- a/spacy_streamlit/visualizer.py
+++ b/spacy_streamlit/visualizer.py
@@ -1,4 +1,4 @@
-from typing import List, Sequence, Tuple, Optional
+from typing import List, Sequence, Tuple, Optional, Dict
 import streamlit as st
 import spacy
 from spacy import displacy
@@ -111,6 +111,7 @@ def visualize_ner(
     show_table: bool = True,
     title: Optional[str] = "Named Entities",
     sidebar_title: Optional[str] = "Named Entities",
+    colors: Dict[str, str] = {},
 ) -> None:
     """Visualizer for named entities."""
     if title:
@@ -120,7 +121,9 @@ def visualize_ner(
     label_select = st.sidebar.multiselect(
         "Entity labels", options=labels, default=list(labels)
     )
-    html = displacy.render(doc, style="ent", options={"ents": label_select})
+    html = displacy.render(
+        doc, style="ent", options={"ents": label_select, "colors": colors}
+    )
     style = "<style>mark.entity { display: inline-block }</style>"
     st.write(f"{style}{get_html(html)}", unsafe_allow_html=True)
     if show_table:


### PR DESCRIPTION
I had some custom entities I added to a trained model and was missing my fav displaCy option to add custom colors for each entity displayed. This adds that functionality by adding a `colors` parameter to `visualize_ner` and passing the corresponding dictionary to `displacy.render`'s `options`. 