### PR TITLE
'labels' parameter of visualize_ner()

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ visualize_ner(doc, labels=nlp.get_pipe("ner").labels)
 | --------------- | ------------- | ----------------------------------------------------------------------------- |
 | `doc`           | `Doc`         | The spaCy `Doc` object to visualize.                                          |
 | _keyword-only_  |               |                                                                               |
-| `labels`        | Sequence[str] | The labels to show in the labels dropdown.                                    |
+| `labels` **(required)**       | Sequence[str] | The labels to show in the labels dropdown.                                    |
 | `attrs`         | List[str]     | The span attributes to show in entity table.                                  |
 | `show_table`    | bool          | Whether to show a table of entities and their attributes. Defaults to `True`. |
 | `title`         | Optional[str] | Title of the visualizer block.                                                |


### PR DESCRIPTION
Hi! The default `labels` parameter of `visualize_ner()` is an [empty tuple](https://github.com/explosion/spacy-streamlit/blob/9592a27645f9bdb0c02c6add02838a506a0aaccf/spacy_streamlit/visualizer.py#L156) and I think we can make it more explicit because today I was debugging to figure out why my custom entities were not being displayed :P. Maybe I'm missing something, what does `keyword-only` mean? (docs table)

Back to the `labels` parameter, I'm not sure if it's best to:

* modify the method to check if the tuple is empty and if so get all labels from the doc
* simply add a required label in the docs

I modified the docs because it's more straightforward, let me know if you think it's not a good path.
Thanks!