### PR TITLE
`visualize_spans` function + `manual` argument + docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,10 @@ from spacy_streamlit import visualize_spans
 
 nlp = spacy.load("en_core_web_sm")
 doc = nlp("Sundar Pichai is the CEO of Google.")
-doc.spans["job_role"] = [doc[4:7]]  # CEO of Google
-visualize_spans(doc, spans_key="job_role")
+span = doc[4:7]  # CEO of Google
+span.label_ = "CEO"
+doc.spans["job_role"] = [span]
+visualize_spans(doc, spans_key="job_role", displacy_options={"colors": {"CEO": "#09a3d5"}})
 ```
 
 | Argument           | Type           | Description                                                                                                                                                        |

--- a/README.md
+++ b/README.md
@@ -117,12 +117,14 @@ doc = nlp("This is a text")
 visualize_parser(doc)
 ```
 
-| Argument        | Type          | Description                                  |
-| --------------- | ------------- | -------------------------------------------- |
-| `doc`           | `Doc`         | The spaCy `Doc` object to visualize.         |
-| _keyword-only_  |               |                                              |
-| `title`         | Optional[str] | Title of the visualizer block.               |
-| `sidebar_title` | Optional[str] | Title of the config settings in the sidebar. |
+| Argument           | Type           | Description                                                                                                                                              |
+| ------------------ | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `doc`              | `Doc`          | The spaCy `Doc` object to visualize.                                                                                                                     |
+| _keyword-only_     |                |                                                                                                                                                          |
+| `title`            | Optional[str]  | Title of the visualizer block.                                                                                                                           |
+| `key`              | Optional[str]  | Key used for the streamlit component for selecting labels.                                                                                               |
+| `manual`           | bool           | Flag signifying whether the doc argument is a Doc object or a List of Dicts containing parse information.                                                |
+| `displacy_optoins` | Optional[Dict] | Dictionary of options to be passed to the displacy render method for generating the HTML to be rendered. See: https://spacy.io/api/top-level#options-dep |
 
 #### <kbd>function</kbd> `visualize_ner`
 
@@ -138,16 +140,47 @@ doc = nlp("Sundar Pichai is the CEO of Google.")
 visualize_ner(doc, labels=nlp.get_pipe("ner").labels)
 ```
 
-| Argument        | Type          | Description                                                                   |
-| --------------- | ------------- | ----------------------------------------------------------------------------- |
-| `doc`           | `Doc`         | The spaCy `Doc` object to visualize.                                          |
-| _keyword-only_  |               |                                                                               |
-| `labels`        | Sequence[str] | The labels to show in the labels dropdown.                                    |
-| `attrs`         | List[str]     | The span attributes to show in entity table.                                  |
-| `show_table`    | bool          | Whether to show a table of entities and their attributes. Defaults to `True`. |
-| `title`         | Optional[str] | Title of the visualizer block.                                                |
-| `sidebar_title` | Optional[str] | Title of the config settings in the sidebar.                                  |
-| `colors`        | Dict[str,str] | A dictionary mapping labels to display colors ({"LABEL": "COLOR"})            |
+| Argument           | Type           | Description                                                                                                                                                                                                                                                 |
+| ------------------ | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `doc`              | `Doc`          | The spaCy `Doc` object to visualize.                                                                                                                                                                                                                        |
+| _keyword-only_     |                |                                                                                                                                                                                                                                                             |
+| `labels`           | Sequence[str]  | The labels to show in the labels dropdown.                                                                                                                                                                                                                  |
+| `attrs`            | List[str]      | The span attributes to show in entity table.                                                                                                                                                                                                                |
+| `show_table`       | bool           | Whether to show a table of entities and their attributes. Defaults to `True`.                                                                                                                                                                               |
+| `title`            | Optional[str]  | Title of the visualizer block.                                                                                                                                                                                                                              |
+| `colors`           | Dict[str,str]  | Dictionary of colors for the entity spans to visualize, with keys as labels and corresponding colors as the values. This argument will be deprecated soon. In future the colors arg need to be passed in the `displacy_options` arg with the key "colors".) |
+| `key`              | Optional[str]  | Key used for the streamlit component for selecting labels.                                                                                                                                                                                                  |
+| `manual`           | bool           | Flag signifying whether the doc argument is a Doc object or a List of Dicts containing entity span                                                                                                                                                          |
+| information.       |
+| `displacy_options` | Optional[Dict] | Dictionary of options to be passed to the displacy render method for generating the HTML to be rendered. See https://spacy.io/api/top-level#displacy_options-ent.                                                                                           |
+
+
+#### <kbd>function</kbd> `visualize_spans`
+
+Visualize spans in a `Doc` using spaCy's
+[`displacy` visualizer](https://spacy.io/usage/visualizers).
+
+```python
+import spacy
+from spacy_streamlit import visualize_spans
+
+nlp = spacy.load("en_core_web_sm")
+doc = nlp("Sundar Pichai is the CEO of Google.")
+doc.spans["job_role"] = [doc[4:7]]  # CEO of Google
+visualize_spans(doc, spans_key="job_role")
+```
+
+| Argument           | Type           | Description                                                                                                                                                        |
+| ------------------ | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `doc`              | `Doc`          | The spaCy `Doc` object to visualize.                                                                                                                               |
+| _keyword-only_     |                |                                                                                                                                                                    |
+| `spans_key`        | Sequence[str]  | Which spans key to render spans from. Default is "sc".                                                                                                             |
+| `attrs`            | List[str]      | The attributes on the entity Span to be labeled. Attributes are displayed only when the `show_table` argument is True.                                             |
+| `show_table`       | bool           | Whether to show a table of spans and their attributes. Defaults to `True`.                                                                                         |
+| `title`            | Optional[str]  | Title of the visualizer block.                                                                                                                                     |
+| `manual`           | bool           | Flag signifying whether the doc argument is a Doc object or a List of Dicts containing entity span information.                                                    |
+| `displacy_options` | Optional[Dict] | Dictionary of options to be passed to the displacy render method for generating the HTML to be rendered. See https://spacy.io/api/top-level#displacy_options-span. |
+
 
 #### <kbd>function</kbd> `visualize_textcat`
 

--- a/examples/05_visualize-spans.py
+++ b/examples/05_visualize-spans.py
@@ -1,0 +1,17 @@
+"""
+Example of using `visualize_spans` with a non-defualt spans_key
+"""
+import spacy_streamlit
+import streamlit as st
+
+import spacy
+from spacy_streamlit import visualize_spans
+
+nlp = spacy.load("en_core_web_sm")
+doc = nlp("Sundar Pichai is the CEO of Google.")
+span = doc[4:7]  # CEO of Google
+span.label_ = "CEO"
+doc.spans["job_role"] = [span]
+visualize_spans(
+    doc, spans_key="job_role", displacy_options={"colors": {"CEO": "#09a3d5"}}
+)

--- a/examples/05_visualize-spans.py
+++ b/examples/05_visualize-spans.py
@@ -1,5 +1,5 @@
 """
-Example of using `visualize_spans` with a non-defualt spans_key
+Example of using `visualize_spans` with a non-default spans_key
 """
 import spacy_streamlit
 import streamlit as st

--- a/spacy_streamlit/__init__.py
+++ b/spacy_streamlit/__init__.py
@@ -1,3 +1,3 @@
-from .visualizer import visualize, visualize_parser, visualize_ner
+from .visualizer import visualize, visualize_parser, visualize_ner, visualize_spans
 from .visualizer import visualize_textcat, visualize_similarity, visualize_tokens
 from .util import load_model, process_text

--- a/spacy_streamlit/visualizer.py
+++ b/spacy_streamlit/visualizer.py
@@ -201,7 +201,7 @@ def visualize_ner(
     title: Optional[str] = "Named Entities",
     colors: Dict[str, str] = {},
     key: Optional[str] = None,
-    manual: Optional[bool] = False,
+    manual: bool = False,
     displacy_options: Optional[Dict] = None,
 ):
     """
@@ -280,7 +280,7 @@ def visualize_spans(
     attrs: List[str] = SPAN_ATTRS,
     show_table: bool = True,
     title: Optional[str] = "Spans",
-    manual: Optional[bool] = False,
+    manual: bool = False,
     displacy_options: Optional[Dict] = None,
 ):
     """

--- a/spacy_streamlit/visualizer.py
+++ b/spacy_streamlit/visualizer.py
@@ -312,13 +312,18 @@ def visualize_spans(
             st.warning(
                 "When the parameter 'manual' is set to True, the parameter 'doc' must be of type 'Dict', not 'spacy.tokens.Doc'."
             )
-
-    html = displacy.render(
-        doc,
-        style="span",
-        options=displacy_options,
-        manual=manual,
-    )
+    try:
+        html = displacy.render(
+            doc,
+            style="span",
+            options=displacy_options,
+            manual=manual,
+        )
+    except ValueError as e:
+        if str(e) == "[E087] Unknown displaCy style: span.":
+            raise ValueError("'visualize_spans' requires spacy>=3.3.0")
+        else:
+            raise e
     st.write(f"{get_html(html)}", unsafe_allow_html=True)
 
     if show_table:

--- a/spacy_streamlit/visualizer.py
+++ b/spacy_streamlit/visualizer.py
@@ -144,6 +144,7 @@ def visualize_parser(
 
     doc (Doc, List): The document to visualize.
     key (str): Key used for the streamlit component for selecting labels.
+    title (str): The title displayed at the top of the parser visualization.
     manual (bool): Flag signifying whether the doc argument is a Doc object or a List of Dicts containing parse information.
     displacy_options (Dict): Dictionary of options to be passed to the displacy render method for generating the HTML to be rendered.
       See: https://spacy.io/api/top-level#options-dep

--- a/spacy_streamlit/visualizer.py
+++ b/spacy_streamlit/visualizer.py
@@ -13,6 +13,9 @@ NER_ATTRS = ["text", "label_", "start", "end", "start_char", "end_char"]
 TOKEN_ATTRS = ["idx", "text", "lemma_", "pos_", "tag_", "dep_", "head", "morph",
                "ent_type_", "ent_iob_", "shape_", "is_alpha", "is_ascii",
                "is_digit", "is_punct", "like_num", "is_sent_start"]
+# Currently these attrs are the same, but they might differ in the future.
+SPAN_ATTRS = NER_ATTRS 
+
 # fmt: on
 FOOTER = """<span style="font-size: 0.75em">&hearts; Built with [`spacy-streamlit`](https://github.com/explosion/spacy-streamlit)</span>"""
 
@@ -180,6 +183,7 @@ def visualize_ner(
     labels (list): The entity labels to visualize.
     attrs (list):  The attributes on the entity Span to be labeled. Attributes are displayed only when the show_table
     argument is True.
+    show_table (bool): Flag signifying whether to show a table with accompanying entity attributes.
     title (str): The title displayed at the top of the NER visualization.
     colors (Dict): Dictionary of colors for the entity spans to visualize, with keys as labels and corresponding colors
     as the values. This argument will be deprecated soon. In future the colors arg need to be passed in the displacy_options arg
@@ -238,6 +242,50 @@ def visualize_ner(
             if data:
                 df = pd.DataFrame(data, columns=attrs)
                 st.dataframe(df)
+
+
+def visualize_spans(
+    doc: spacy.tokens.Doc,
+    *,
+    spans_key: str = "sc",
+    attrs: List[str] = SPAN_ATTRS,
+    show_table: bool = True,
+    title: Optional[str] = "Spans",
+    displacy_options: Optional[Dict] = None,
+):
+    """
+    Visualizer for spans.
+
+    doc (Doc, List): The document to visualize.
+    spans_key (str): Which spans key to render spans from. Default is "sc".
+    attrs (list):  The attributes on the entity Span to be labeled. Attributes are displayed only when the show_table
+    argument is True.
+    show_table (bool): Flag signifying whether to show a table with accompanying span attributes.
+    title (str): The title displayed at the top of the Spans visualization.
+    displacy_options (Dict): Dictionary of options to be passed to the displacy render method for generating the HTML to be rendered.
+    """
+    if not displacy_options:
+        displacy_options = dict()
+    displacy_options["spans_key"] = spans_key
+
+    if title:
+        st.header(title)
+
+    html = displacy.render(
+        doc,
+        style="span",
+        options=displacy_options,
+    )
+    st.write(f"{get_html(html)}", unsafe_allow_html=True)
+
+    if show_table:
+        data = [
+            [str(getattr(span, attr)) for attr in attrs]
+            for span in doc.spans[spans_key]
+        ]
+        if data:
+            df = pd.DataFrame(data, columns=attrs)
+            st.dataframe(df)
 
 
 def visualize_textcat(

--- a/spacy_streamlit/visualizer.py
+++ b/spacy_streamlit/visualizer.py
@@ -320,6 +320,8 @@ def visualize_spans(
             manual=manual,
         )
     except ValueError as e:
+        # Note: This will break if this error message ever changes,
+        # but this will then throw the original (and still informative) error
         if str(e) == "[E087] Unknown displaCy style: span.":
             raise ValueError("'visualize_spans' requires spacy>=3.3.0")
         else:

--- a/spacy_streamlit/visualizer.py
+++ b/spacy_streamlit/visualizer.py
@@ -7,6 +7,7 @@ import pandas as pd
 
 from .util import load_model, process_text, get_svg, get_html, LOGO
 
+SPACY_VERSION = tuple(map(int, spacy.__version__.split(".")))
 
 # fmt: off
 NER_ATTRS = ["text", "label_", "start", "end", "start_char", "end_char"]
@@ -296,6 +297,10 @@ def visualize_spans(
     displacy_options (Dict): Dictionary of options to be passed to the displacy render method for generating the HTML to be rendered.
       See https://spacy.io/api/top-level#displacy_options-span
     """
+    if SPACY_VERSION < (3, 3, 0):
+        raise ValueError(
+            f"'visualize_spans' requires spacy>=3.3.0. You have spacy=={spacy.__version__}"
+        )
     if not displacy_options:
         displacy_options = dict()
     displacy_options["spans_key"] = spans_key
@@ -312,20 +317,12 @@ def visualize_spans(
             st.warning(
                 "When the parameter 'manual' is set to True, the parameter 'doc' must be of type 'Dict', not 'spacy.tokens.Doc'."
             )
-    try:
-        html = displacy.render(
-            doc,
-            style="span",
-            options=displacy_options,
-            manual=manual,
-        )
-    except ValueError as e:
-        # Note: This will break if this error message ever changes,
-        # but this will then throw the original (and still informative) error
-        if str(e) == "[E087] Unknown displaCy style: span.":
-            raise ValueError("'visualize_spans' requires spacy>=3.3.0")
-        else:
-            raise e
+    html = displacy.render(
+        doc,
+        style="span",
+        options=displacy_options,
+        manual=manual,
+    )
     st.write(f"{get_html(html)}", unsafe_allow_html=True)
 
     if show_table:


### PR DESCRIPTION
Adds a `visualize_spans` function for using the span visualization in displaCy.

I made a few choices that may need justification:
- Even though `spans_key` is part of the `options` passed to displaCy, it feels critical enough to pass as an argument to `visualize_spans` rather than as a key/value in a dict to `displacy_options` - but we can obviously undo this.
- I didn't include the span viz in the "display everything" `visualize` function because none of the base models will have labeled spans in them, so it wouldn't display anything useful.
- Compared to `visualize_ner`:
  - I removed the `manual` argument because there's no such option for that with displaCy for spans
  - There's no label filtering/selection with spans, so all labels will be displayed for spans within a `span_key`. This removes the `keys` and `labels` args.

Extra:
- Also added a missing docstring for the `show_table` argument on `visualize_ner` (as well as `visualize_spans`)


Open questions:
- Is there a script to generate the nice `readme.md` documentation so we can include the new function?
- I'm not totally sure what needs to happen for a release, but I'm happy to help do whatever needs to be done!