### PR TITLE
Update st.cache deprecation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-streamlit>=0.86.0
+streamlit>=1.18.0
 spacy>=3.0.0,<4.0.0
 pandas

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ long_description_content_type = text/markdown
 zip_safe = true
 python_requires = >=3.6
 install_requires =
-    streamlit>=0.86.0
+    streamlit>=1.18.0
     spacy>=3.0.0,<4.0.0
     pandas
 

--- a/spacy_streamlit/util.py
+++ b/spacy_streamlit/util.py
@@ -3,13 +3,13 @@ import spacy
 import base64
 
 
-@st.cache_resources(allow_output_mutation=True, suppress_st_warning=True)
+@st.cache_resource
 def load_model(name: str) -> spacy.language.Language:
     """Load a spaCy model."""
     return spacy.load(name)
 
 
-@st.cache_data(allow_output_mutation=True, suppress_st_warning=True)
+@st.cache_data
 def process_text(model_name: str, text: str) -> spacy.tokens.Doc:
     """Process a text and create a Doc object."""
     nlp = load_model(model_name)

--- a/spacy_streamlit/util.py
+++ b/spacy_streamlit/util.py
@@ -3,13 +3,13 @@ import spacy
 import base64
 
 
-@st.cache(allow_output_mutation=True, suppress_st_warning=True)
+@st.cache_resources(allow_output_mutation=True, suppress_st_warning=True)
 def load_model(name: str) -> spacy.language.Language:
     """Load a spaCy model."""
     return spacy.load(name)
 
 
-@st.cache(allow_output_mutation=True, suppress_st_warning=True)
+@st.cache_data(allow_output_mutation=True, suppress_st_warning=True)
 def process_text(model_name: str, text: str) -> spacy.tokens.Doc:
     """Process a text and create a Doc object."""
     nlp = load_model(model_name)


### PR DESCRIPTION
I've updated the two cases of `st.cache` (deprecated) to the new `st.cache_resources` and `st.cache_data`. 

I'm not sure how to test this without repackaging, so I've kept this as a draft. Also, should I update the `requirements.txt` to the version where these changes were made (1.18)?